### PR TITLE
Add Recaptcha to Signup Page

### DIFF
--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -7,6 +7,6 @@ module.exports = merge(prodEnv, {
   ROOT_PATH: '"http://localhost:9090"',
   API_PATH: '"https://localhost:4040"',
   FACEBOOK_CLIENT_ID: '""', // CHANGE THIS
-  GITHUB_CLIENT_ID: '"4ec1203397f6f27694bd"', // CHANGE THIS
+  GITHUB_CLIENT_ID: '"4a310d203eed23fd8923"', // CHANGE THIS
   LINKEDIN_CLIENT_ID: '""' // CHANGE THIS
 })

--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -7,6 +7,6 @@ module.exports = merge(prodEnv, {
   ROOT_PATH: '"http://localhost:9090"',
   API_PATH: '"https://localhost:4040"',
   FACEBOOK_CLIENT_ID: '""', // CHANGE THIS
-  GITHUB_CLIENT_ID: '"4a310d203eed23fd8923"', // CHANGE THIS
+  GITHUB_CLIENT_ID: '"4ec1203397f6f27694bd"', // CHANGE THIS
   LINKEDIN_CLIENT_ID: '""' // CHANGE THIS
 })

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <link rel="shortcut icon" type="image/png" href="/static/favicon.ico"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>utopian-registration</title>
+    <script src="https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit" async defer>
+</script>
   </head>
   <body>
     <div id="app"></div>

--- a/index.html
+++ b/index.html
@@ -2,12 +2,13 @@
 <html>
   <head>
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans:bold|Lato:300,300i,400,400i,500,500i,600,600i,700,700i,800,800i" rel="stylesheet">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+
     <meta charset="utf-8">
     <link rel="shortcut icon" type="image/png" href="/static/favicon.ico"/>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>utopian-registration</title>
-    <script src="https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit" async defer>
-</script>
+    <script src="https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit" async defer></script>
   </head>
   <body>
     <div id="app"></div>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "vue-cookies": "^1.5.4",
     "vue-js-modal": "^1.3.9",
     "vue-notification": "^1.3.6",
+    "vue-recaptcha": "^1.1.1",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "axios": "^0.17.1",
     "dsteem": "^0.8.6",
+    "lodash": "^4.17.10",
     "steem": "^0.6.7",
     "vue": "^2.5.13",
     "vue-authenticate": "^1.3.4",

--- a/src/App.vue
+++ b/src/App.vue
@@ -166,6 +166,11 @@ a {
   font-size:14px !important;
 }
 
+.text__success {
+  color:#28a745 !important;
+  font-size:14px !important;
+}
+
 .text__grey {
     text-align:center !important;
     color: #b1b2b5;

--- a/src/components/signup.vue
+++ b/src/components/signup.vue
@@ -23,16 +23,6 @@
         <!--<div><button class="btn__signin" id="linkedin" @click="authenticate('linkedin')"><img src="./../assets/ic_linkedIn.svg"><span>SIGN IN WITH LINKEDIN</span></button></div>-->
         <!--<div><button class="btn__signin" id="email" @click="signIn('/verify_mail')"><img src="./../assets/ic_email.svg"><span>SIGN IN WITH EMAIL </span></button></div>-->
         <!--<p style="margin-bottom:0">Accounts will be created on the TESTNET for now.</p>-->
-          <div v-cloak class="">
-            <div v-show="serverError">
-              {{serverError}}
-            </div>
-          </div>
-          <div class="successful-server-response-wrapper" v-cloak>
-            <div v-show="sucessfulServerResponse" class="successful-server-response">
-              {{sucessfulServerResponse}}
-            </div>
-          </div>
       </div>
     </div>
     <Login/>

--- a/src/components/signup.vue
+++ b/src/components/signup.vue
@@ -5,13 +5,29 @@
         <h1>Welcome to Utopian.io</h1>
         <p>Register with your GitHub account to get instant access to Utopian services and a free STEEM account and wallet. <a href="https://join.utopian.io" target="_blank">Learn More About Utopian</a></p>
         <div>
-          <button class="btn__signin" id="github" @click="authenticate('github')"><img src="./../assets/ic_github.svg"><span>SIGN IN WITH GITHUB</span></button>
-                  <small>The GitHub account linked to the Utopian services cannot be changed.</small>
+          <vue-recaptcha 
+            ref="recaptcha"
+            @verify="onCaptchaVerified"
+            @expired="onCaptchaExpired"
+            sitekey="6LcavVkUAAAAAKl5cJB-zQG8eW_qge_JyTWE3STx">
+            <button class="btn__signin" id="github" @click="authenticateV2('github')"><img src="./../assets/ic_github.svg"><span>SIGN IN WITH GITHUB</span></button>
+          </vue-recaptcha>
+          <small>The GitHub account linked to the Utopian services cannot be changed.</small>
         </div>
         <!--<div><button class="btn__signin" id="facebook" @click="authenticate('facebook')"><img src="./../assets/ic_facebook.svg"><span>SIGN IN WITH FACEBOOK</span></button></div>-->
         <!--<div><button class="btn__signin" id="linkedin" @click="authenticate('linkedin')"><img src="./../assets/ic_linkedIn.svg"><span>SIGN IN WITH LINKEDIN</span></button></div>-->
         <!--<div><button class="btn__signin" id="email" @click="signIn('/verify_mail')"><img src="./../assets/ic_email.svg"><span>SIGN IN WITH EMAIL </span></button></div>-->
         <!--<p style="margin-bottom:0">Accounts will be created on the TESTNET for now.</p>-->
+          <div v-cloak class="">
+            <div v-show="serverError">
+              {{serverError}}
+            </div>
+          </div>
+          <div class="successful-server-response-wrapper" v-cloak>
+            <div v-show="sucessfulServerResponse" class="successful-server-response">
+              {{sucessfulServerResponse}}
+            </div>
+          </div>
       </div>
     </div>
     <Login/>
@@ -21,6 +37,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import VueRecaptcha from 'vue-recaptcha';
 import Login from './partials/login'
 export default {
   name: 'signup',
@@ -31,6 +48,7 @@ export default {
   },
   methods: {
     signIn(to) { this.$router.push(to) },
+    
     authenticate(provider) {
     if(this.$cookies.get('c_a')) return  this.$notify({ group: 'main', text: 'You have already created an account through Utopian', type:'error' })
       this.$store.dispatch('authenticate', { provider })
@@ -48,7 +66,8 @@ export default {
     }
   },
   components: {
-    Login
+    Login,
+    VueRecaptcha
   }
 }
 </script>

--- a/src/components/signup.vue
+++ b/src/components/signup.vue
@@ -5,11 +5,17 @@
         <h1>Welcome to Utopian.io</h1>
         <p>Register with your GitHub account to get instant access to Utopian services and a free STEEM account and wallet. <a href="https://join.utopian.io" target="_blank">Learn More About Utopian</a></p>
         <div>
-          <vue-recaptcha 
+          <vue-recaptcha
+            ref="recaptcha"
             @verify="onCaptchaVerified"
             @expired="onCaptchaExpired"
             sitekey="6Ld06lkUAAAAAGTusc2d373DU6PvotibJ6ilxpqX">
-            <button class="btn__signin" id="github"><img src="./../assets/ic_github.svg"><span>SIGN IN WITH GITHUB</span></button>
+            <button
+              class="btn__signin"
+              id="github"
+              :disabled="status==='submitting'">
+                <img src="./../assets/ic_github.svg"><span>SIGN IN WITH GITHUB</span>
+            </button>
           </vue-recaptcha>
           <small>The GitHub account linked to the Utopian services cannot be changed.</small>
         </div>
@@ -47,8 +53,17 @@ export default {
   },
   methods: {
     signIn(to) { this.$router.push(to) },
-    onCaptchaVerified() {
+    onCaptchaVerified(recaptchaToken) {
       console.log('onCaptchaVerified')
+      console.log(this)
+      console.log(recaptchaToken)
+
+      const self = this
+      self.status = "submitting"
+      self.$refs.recaptcha.reset()
+    },
+    onCaptchaExpired: function () {
+      this.$refs.recaptcha.reset()
     },
     authenticate(provider) {
     if(this.$cookies.get('c_a')) return  this.$notify({ group: 'main', text: 'You have already created an account through Utopian', type:'error' })
@@ -122,6 +137,11 @@ export default {
   text-align:center !important;
   color: #b1b2b5;
   font-size:12px;
+}
+
+.btn__signin[disabled] {
+  opacity:0.5;
+  cursor: not-allowed;
 }
 
 #github {

--- a/src/components/signup.vue
+++ b/src/components/signup.vue
@@ -6,11 +6,10 @@
         <p>Register with your GitHub account to get instant access to Utopian services and a free STEEM account and wallet. <a href="https://join.utopian.io" target="_blank">Learn More About Utopian</a></p>
         <div>
           <vue-recaptcha 
-            ref="recaptcha"
             @verify="onCaptchaVerified"
             @expired="onCaptchaExpired"
-            sitekey="6LcavVkUAAAAAKl5cJB-zQG8eW_qge_JyTWE3STx">
-            <button class="btn__signin" id="github" @click="authenticateV2('github')"><img src="./../assets/ic_github.svg"><span>SIGN IN WITH GITHUB</span></button>
+            sitekey="6Ld06lkUAAAAAGTusc2d373DU6PvotibJ6ilxpqX">
+            <button class="btn__signin" id="github"><img src="./../assets/ic_github.svg"><span>SIGN IN WITH GITHUB</span></button>
           </vue-recaptcha>
           <small>The GitHub account linked to the Utopian services cannot be changed.</small>
         </div>
@@ -48,7 +47,9 @@ export default {
   },
   methods: {
     signIn(to) { this.$router.push(to) },
-    
+    onCaptchaVerified() {
+      console.log('onCaptchaVerified')
+    },
     authenticate(provider) {
     if(this.$cookies.get('c_a')) return  this.$notify({ group: 'main', text: 'You have already created an account through Utopian', type:'error' })
       this.$store.dispatch('authenticate', { provider })

--- a/src/components/signup.vue
+++ b/src/components/signup.vue
@@ -7,8 +7,8 @@
         <div>
           <vue-recaptcha
             ref="recaptcha"
-            @verify="onCaptchaVerified"
-            @expired="onCaptchaExpired"
+            @verify="onGithubCaptchaVerified"
+            @expired="onGithubCaptchaExpired"
             sitekey="6Ld06lkUAAAAAGTusc2d373DU6PvotibJ6ilxpqX">
             <button
               class="btn__signin"
@@ -53,32 +53,29 @@ export default {
   },
   methods: {
     signIn(to) { this.$router.push(to) },
-    onCaptchaVerified(recaptchaToken) {
-      console.log('onCaptchaVerified')
-      console.log(this)
-      console.log(recaptchaToken)
-
+    onGithubCaptchaVerified(recaptchaToken) {
       const self = this
       self.status = "submitting"
       self.$refs.recaptcha.reset()
+      self.authenticate('github')
     },
-    onCaptchaExpired: function () {
+    onGithubCaptchaExpired() {
       this.$refs.recaptcha.reset()
     },
     authenticate(provider) {
-    if(this.$cookies.get('c_a')) return  this.$notify({ group: 'main', text: 'You have already created an account through Utopian', type:'error' })
-      this.$store.dispatch('authenticate', { provider })
-      .then(response => {
-        if(response.status !== 200) {
-          this.$notify({ group: 'main', text: response.message, type:'error' })
-          return this.$router.push('/')
-        }
-        let user = response.data.user
-        if(user.has_created_account) { this.$notify({ group: 'main', text: 'This social account has already been used to create an account', type:'error' }); return this.$router.push('/') }
-        if((user.social_verified || user.sms_verified) && user.email_verified) { this.$router.push('/pick_account') }
-        else if(!user.email_verified) { this.$router.push('/verify_mail') }
-        else { this.$router.push('/verify_phone') }
-      })
+      if(this.$cookies.get('c_a')) return  this.$notify({ group: 'main', text: 'You have already created an account through Utopian', type:'error' })
+        this.$store.dispatch('authenticate', { provider })
+        .then(response => {
+          if(response.status !== 200) {
+            this.$notify({ group: 'main', text: response.message, type:'error' })
+            return this.$router.push('/')
+          }
+          let user = response.data.user
+          if(user.has_created_account) { this.$notify({ group: 'main', text: 'This social account has already been used to create an account', type:'error' }); return this.$router.push('/') }
+          if((user.social_verified || user.sms_verified) && user.email_verified) { this.$router.push('/pick_account') }
+          else if(!user.email_verified) { this.$router.push('/verify_mail') }
+          else { this.$router.push('/verify_phone') }
+        })
     }
   },
   components: {

--- a/src/components/steps/account/pick_account.vue
+++ b/src/components/steps/account/pick_account.vue
@@ -7,8 +7,26 @@
         <h1>Welcome to Utopian.io</h1>
         <p style="margin-bottom:15px;">Choose an account name to use on Utopian. Note that you cannot change your account name after selection.</p>
         <div class="PickAccount__Input">
-          <input class="Input__utopian" style="margin-right:10px;" placeholder="Enter your username" v-model="input_account"/>
-          <button class="Btn__blue" :disabled="false" @click="chooseAccount()">CONTINUE</button>
+          <input 
+            class="Input__utopian"
+            v-bind:class="{ available: !this.input_error && this.input_account, unavailable: this.input_error }"
+            style="margin-right:10px;" 
+            placeholder="Enter your username"
+            v-model="input_account"/>
+          <span
+            class="valid-feedback feedback-icon">
+            v-bind:class="{ valid-check: this.input_account !== '' }"
+            <i class="fa fa-check" id="validIcon"></i>
+          </span>
+          <span
+            class="invalid-feedback feedback-icon">
+            v-bind:class="{ valid-check: this.input_account !== '' }"
+            <i class="fa fa-times"></i>
+          </span>
+          <button
+            class="Btn__blue"
+            :disabled="this.input_error !== ''"
+            @click="chooseAccount()">CONTINUE</button>
         </div>
         <div class="Checkbox__container">
           <p style="margin:0" class="text__grey">Terms of Service: </p>
@@ -134,6 +152,43 @@ export default {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.unavailable {
+  border-color: #dc3545;
+}
+
+.available {
+  border-color: #28a745;
+  box-shadow: 0 0 0 0.2rem rgba(40,167,69,.25)
+}
+
+.valid-feedback.feedback-icon,
+.invalid-feedback.feedback-icon {
+    position: relative;
+    bottom: 10px;
+    right: 35px;
+    margin-top: 17px;
+}
+
+.valid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 80%;
+  color: #28a745;
+}
+
+.valid-check {
+  display: block;
+}
+
+.invalid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 80%;
+  color: #dc3545;
 }
 
 </style>

--- a/src/components/steps/account/pick_account.vue
+++ b/src/components/steps/account/pick_account.vue
@@ -33,7 +33,9 @@ export default {
     ])
   },
   watch: {
-    input_account: function() {
+    input_account: function(input) {
+      console.log(input)
+      this.input_account = input.toLowerCase().trim()
       this.validateAccountName()
     },
   },

--- a/src/components/steps/account/pick_account.vue
+++ b/src/components/steps/account/pick_account.vue
@@ -16,17 +16,17 @@
             v-on:keypress="loading = true"/>
           <span
             class="valid-feedback feedback-icon"
-            v-if="this.loading && this.input_account">
+            v-show="this.loading && this.input_account">
             <i class="fa fa-spinner fa-spin"></i>
           </span>
           <span
             class="valid-feedback feedback-icon"
-            v-if="!this.loading && this.input_account && this.input_error === ''">
+            v-show="!this.loading && this.input_account && this.input_error === ''">
             <i class="fa fa-check" id="validIcon"></i>
           </span>
           <span
             class="invalid-feedback feedback-icon"
-            v-if="!this.loading && this.input_account && this.input_error !== ''">
+            v-show="!this.loading && this.input_account && this.input_error !== ''">
             <i class="fa fa-times"></i>
           </span>
           <button
@@ -34,7 +34,20 @@
             :disabled="this.loading || this.input_error !== ''"
             @click="chooseAccount()">CONTINUE</button>
         </div>
-        <div v-show="this.input_error" style="height:24px;width:100%;"><p class="text__error" v-show="this.input_error">{{input_error}}</p></div>
+        <div
+          v-show="this.input_error"
+          style="height:24px;width:100%;">
+          <p class="text__error"
+            v-show="this.input_error"
+            v-html="this.input_error"></p>
+        </div>
+        <div
+          v-show="this.success_msg"
+          style="height:24px;width:100%;">
+          <p class="text__success"
+            v-show="this.success_msg"
+            v-html="this.success_msg"></p>
+        </div>
         <div class="Checkbox__container">
           <p style="margin:0" class="text__grey">Terms of Service: </p>
           <input v-model="accept_checked" class="Checkbox__utopian" type="checkbox">
@@ -71,6 +84,7 @@ export default {
     return {
       input_account: '',
       input_error: '',
+      success_msg: '',
       accept_checked: false,
       loading: false
     }
@@ -100,8 +114,9 @@ export default {
 
       this.$store.dispatch('getAccount', { account: this.input_account })
         .then(account => {
-          this.input_error = account ? 'The username ' + this.input_account + ' is already in use' : ''
           this.loading = false
+          this.input_error = account ? 'The username <b>' + this.input_account + '</b> is already in use' : ''
+          this.success_msg = this.input_error ? '' : 'The username <b>' + this.input_account + '</b> is available'
         })
       return this.input_error
     },

--- a/src/components/steps/account/pick_account.vue
+++ b/src/components/steps/account/pick_account.vue
@@ -9,18 +9,18 @@
         <div class="PickAccount__Input">
           <input 
             class="Input__utopian"
-            v-bind:class="{ available: !this.input_error && this.input_account, unavailable: this.input_error }"
+            v-bind:class="{ 'is-valid': !this.input_error && this.input_account, 'is-invalid': this.input_error }"
             style="margin-right:10px;" 
             placeholder="Enter your username"
             v-model="input_account"/>
           <span
-            class="valid-feedback feedback-icon">
-            v-bind:class="{ valid-check: this.input_account !== '' }"
+            class="valid-feedback feedback-icon"
+            v-if="this.input_account && this.input_error === ''">
             <i class="fa fa-check" id="validIcon"></i>
           </span>
           <span
-            class="invalid-feedback feedback-icon">
-            v-bind:class="{ valid-check: this.input_account !== '' }"
+            class="invalid-feedback feedback-icon"
+            v-if="this.input_account && this.input_error !== ''">
             <i class="fa fa-times"></i>
           </span>
           <button
@@ -28,12 +28,12 @@
             :disabled="this.input_error !== ''"
             @click="chooseAccount()">CONTINUE</button>
         </div>
+        <div v-show="this.input_error" style="height:24px;width:100%;"><p class="text__error" v-show="this.input_error">{{input_error}}</p></div>
         <div class="Checkbox__container">
           <p style="margin:0" class="text__grey">Terms of Service: </p>
           <input v-model="accept_checked" class="Checkbox__utopian" type="checkbox">
           <a style="font-size:14px; margin-left:5px;" href="https://join.utopian.io/tos" target="_blank">Read</a>
         </div>
-        <div v-show="this.input_error" style="height:24px;width:100%;"><p class="text__error" v-show="this.input_error">{{input_error}}</p></div>
       </div>
     </div>
     <Login/>
@@ -154,38 +154,31 @@ export default {
   justify-content: space-between;
 }
 
-.unavailable {
+.is-invalid {
   border-color: #dc3545;
 }
 
-.available {
+.is-valid {
   border-color: #28a745;
   box-shadow: 0 0 0 0.2rem rgba(40,167,69,.25)
 }
 
 .valid-feedback.feedback-icon,
 .invalid-feedback.feedback-icon {
-    position: relative;
-    bottom: 10px;
-    right: 35px;
-    margin-top: 17px;
+  position: absolute;
+  display: block;
+  width: auto;
+  margin-left: 210px;
+  margin-top: 0px;
 }
 
 .valid-feedback {
-  display: none;
-  width: 100%;
   margin-top: 0.25rem;
   font-size: 80%;
   color: #28a745;
 }
 
-.valid-check {
-  display: block;
-}
-
 .invalid-feedback {
-  display: none;
-  width: 100%;
   margin-top: 0.25rem;
   font-size: 80%;
   color: #dc3545;

--- a/src/components/steps/account/pick_account.vue
+++ b/src/components/steps/account/pick_account.vue
@@ -9,9 +9,9 @@
         <div class="PickAccount__Input">
           <input 
             class="Input__utopian"
-            v-bind:class="{ 'is-valid': !this.input_error && this.input_account, 'is-invalid': this.input_error }"
             style="margin-right:10px;" 
             placeholder="Enter your username"
+            v-bind:class="{ 'is-valid': !this.input_error && this.input_account, 'is-invalid': this.input_error }"
             v-model="input_account"/>
           <span
             class="valid-feedback feedback-icon"
@@ -44,6 +44,7 @@
 import loadingbar from './../../partials/loading_bars/loading_bar_start.vue'
 import Login from './../../partials/login'
 import { mapGetters } from 'vuex'
+
 export default {
   computed: {
     ...mapGetters([
@@ -52,10 +53,9 @@ export default {
   },
   watch: {
     input_account: function(input) {
-      console.log(input)
       this.input_account = input.toLowerCase().trim()
       this.validateAccountName()
-    },
+    }
   },
   components: {
     loadingbar
@@ -90,9 +90,10 @@ export default {
       } else { this.input_error = '' }
 
       this.$store.dispatch('getAccount', { account: this.input_account })
-        .then(account => { this.input_error = account ? 'Account name not available' : '' })
-        console.log(this.input_error)
-        return this.input_error
+        .then(account => {
+          this.input_error = account ? 'The username ' + this.input_account + ' is already in use' : ''
+        })
+      return this.input_error
     },
     validationRules(value) {
       let i, label, len, suffix;


### PR DESCRIPTION
Fixes #21 

1. First screen should be a recaptcha
    - added recaptcha to signup page
2. Add a better alert if the username is already taken
    - added debounce to delay username verification (for fast typing); 
    - added valid (check mark) and invalid (x mark) to indicate available and unavailable account names;
    - display a success message when account name is available

### Account Check

![add-recaptcha-to-signup](https://user-images.githubusercontent.com/29425738/40268872-783d7dd6-5bb0-11e8-8e71-440b5977449a.gif)

### Input Recaptcha

![recaptcha](https://user-images.githubusercontent.com/29425738/40278171-0166c160-5c67-11e8-87da-89bef2f06ddb.gif)
